### PR TITLE
Support multi-arch / arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Build & Push
-# Build & Push builds the simapp docker image on every push to master and
-# and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
+# Build & Push builds the Terra Core Docker image on every push to master
+# and publishes the image to https://hub.docker.com/r/terramoney/core/tags
 on:
   pull_request:
   push:
@@ -38,8 +38,14 @@ jobs:
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
           fi
           echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=alpine_tags::${TAGS}
+          echo ::set-output name=ubuntu_tags::$(echo ${TAGS} | sed s/core/core-shared/g)
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -50,8 +56,18 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
+      - name: Publish Alpine image to Docker Hub
         uses: docker/build-push-action@v2
         with:
+          file: Dockerfile
           push: ${{ github.event_name != 'pull_request' && !contains(github.ref, 'release') }}
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.prep.outputs.alpine_tags }}
+          platforms: linux/amd64 # does not currently link under arm64
+
+      - name: Publish Ubuntu image to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          file: shared.Dockerfile
+          push: ${{ github.event_name != 'pull_request' && !contains(github.ref, 'release') }}
+          tags: ${{ steps.prep.outputs.ubuntu_tags }}
+          platforms: linux/amd64,linux/arm64

--- a/shared.Dockerfile
+++ b/shared.Dockerfile
@@ -1,24 +1,45 @@
-FROM golang:1.17-buster AS go-builder
+ARG RUST_VERSION=1.60.0
+ARG GO_VERSION=1.17.8
+ARG BUILD_MODE=src
 
-# Install minimum necessary dependencies, build Cosmos SDK, remove packages
-RUN apt update
-RUN apt install -y curl git build-essential
-# debug: for live editting in the image
-RUN apt install -y vim
-
+FROM rust:${RUST_VERSION}-buster AS rust-builder-src
 WORKDIR /code
-COPY . /code/
 
+# build libwasmvm
+ARG WASMVM_VERSION=0.16.6
+ARG WASMVM_SHA256=3df181d7ab80e44d55ad31ebf7ee983831abe43764781c3e07b94d20b703d079
+RUN set -eux; \
+    wget https://github.com/CosmWasm/wasmvm/archive/refs/tags/v${WASMVM_VERSION}.tar.gz -O wasmvm.tar.gz; \
+    echo "${WASMVM_SHA256} *wasmvm.tar.gz" | sha256sum -c -; \
+    tar xf wasmvm.tar.gz --strip-components=1; \
+    rm wasmvm.tar.gz; \
+    cd libwasmvm; \
+    cargo build --release
+
+# support pre-built libwasmvm using the arg BUILD_MODE=bin
+FROM scratch AS rust-builder-bin
+WORKDIR /code/libwasmvm/target/release/deps
+COPY libwasmvm.so ./
+
+FROM rust-builder-${BUILD_MODE} AS rust-builder
+
+FROM golang:${GO_VERSION}-buster AS go-builder
+WORKDIR /code
+
+# install deps
+RUN apt update && \
+    apt install -y curl git build-essential vim
+
+# build terrad
+COPY . /code
+COPY --from=rust-builder /code/libwasmvm/target/release/deps/libwasmvm.so /lib/libwasmvm.so
 RUN LEDGER_ENABLED=false make build
 
-RUN cp /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/api/libwasmvm.so /lib/libwasmvm.so
-
-FROM ubuntu:20.04
-
+FROM ubuntu:20.04 AS runtime
 WORKDIR /root
 
+COPY --from=rust-builder /code/libwasmvm/target/release/deps/libwasmvm.so /lib/libwasmvm.so
 COPY --from=go-builder /code/build/terrad /usr/local/bin/terrad
-COPY --from=go-builder /lib/libwasmvm.so /lib/libwasmvm.so
 
 # rest server
 EXPOSE 1317


### PR DESCRIPTION
This PR adds support for multi-arch / arm64 builds. Continuation of #693.

- Support amd64+arm64 builds for muslc libwasmvm using pre-built artifacts from CosmWasm
- Support amd64+arm64 builds for libc libwasmvm by building from source
- Build & publish multi-arch images from the CI pipeline