### PR TITLE
(Re)Enable Staking and Delegation on classic-core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ replace (
 	// security patches:
 	//
 	// - https://github.com/terra-money/cosmos-sdk/pull/63
-	github.com/cosmos/cosmos-sdk => github.com/terra-money/cosmos-sdk v0.44.6-0.20220512154111-515df8b16c89
+	github.com/cosmos/cosmos-sdk => github.com/terra-money/cosmos-sdk v0.44.6-0.20220331002058-d6d8837778da
 	github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tecbot/gorocksdb => github.com/cosmos/gorocksdb v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -800,8 +800,8 @@ github.com/tendermint/tm-db v0.5.1/go.mod h1:g92zWjHpCYlEvQXvy9M168Su8V1IBEeawpX
 github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/tendermint/tm-db v0.6.6 h1:EzhaOfR0bdKyATqcd5PNeyeq8r+V4bRPHBfyFdD9kGM=
 github.com/tendermint/tm-db v0.6.6/go.mod h1:wP8d49A85B7/erz/r4YbKssKw6ylsO/hKtFk7E1aWZI=
-github.com/terra-money/cosmos-sdk v0.44.6-0.20220512154111-515df8b16c89 h1:yz8rtH9EgEIpSEHMScM8C4SS3AdR38M8h68q8urSFo4=
-github.com/terra-money/cosmos-sdk v0.44.6-0.20220512154111-515df8b16c89/go.mod h1:/tqCMnVCrX7F7iL2ALCsGdYmhx0jfgFG/50gP8jt6bI=
+github.com/terra-money/cosmos-sdk v0.44.6-0.20220331002058-d6d8837778da h1:wuzAPZ945Cnvq/0PvMn8Fq4eqNXo8ScQQmbaI2ETvxI=
+github.com/terra-money/cosmos-sdk v0.44.6-0.20220331002058-d6d8837778da/go.mod h1:/tqCMnVCrX7F7iL2ALCsGdYmhx0jfgFG/50gP8jt6bI=
 github.com/terra-money/ledger-terra-go v0.11.2 h1:BVXZl+OhJOri6vFNjjVaTabRLApw9MuG7mxWL4V718c=
 github.com/terra-money/ledger-terra-go v0.11.2/go.mod h1:ClJ2XMj1ptcnONzKH+GhVPi7Y8pXIT+UzJ0TNt0tfZE=
 github.com/terra-money/tendermint v0.34.14-terra.2 h1:UYDDCI001ZNhs+aX09HjKVldUcz084q3RwLHUOSSZQU=


### PR DESCRIPTION
This PR reverts back to the commit to cosmos-sdk to the state right before the CreateValidator and Delegate functions were disabled at height 7603700.  

This will renable staking and delegation on luna classic.

## Summary of changes

replace go.mod deps for terra-money/cosmos-sdk to the version before staking was removed.
the commit right before was pull request #37 on release v0.44.x
https://github.com/terra-money/cosmos-sdk/commits/release/v0.44.x
