### PR TITLE
Revert staking security patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,11 +123,8 @@ require (
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 
-	// Commit 515df8b16c89 points the release/v0.44.x branch with the following
-	// security patches:
-	//
-	// - https://github.com/terra-money/cosmos-sdk/pull/63
-	github.com/cosmos/cosmos-sdk => github.com/terra-money/cosmos-sdk v0.44.6-0.20220512154111-515df8b16c89
+	// Revert to previous version of cosmos SDK with no height-gated disabling of MsgDelegate and MsgCreateValidator
+	github.com/cosmos/cosmos-sdk => github.com/terra-money/cosmos-sdk v0.44.5-terra.2
 	github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tecbot/gorocksdb => github.com/cosmos/gorocksdb v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -800,8 +800,8 @@ github.com/tendermint/tm-db v0.5.1/go.mod h1:g92zWjHpCYlEvQXvy9M168Su8V1IBEeawpX
 github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/tendermint/tm-db v0.6.6 h1:EzhaOfR0bdKyATqcd5PNeyeq8r+V4bRPHBfyFdD9kGM=
 github.com/tendermint/tm-db v0.6.6/go.mod h1:wP8d49A85B7/erz/r4YbKssKw6ylsO/hKtFk7E1aWZI=
-github.com/terra-money/cosmos-sdk v0.44.6-0.20220512154111-515df8b16c89 h1:yz8rtH9EgEIpSEHMScM8C4SS3AdR38M8h68q8urSFo4=
-github.com/terra-money/cosmos-sdk v0.44.6-0.20220512154111-515df8b16c89/go.mod h1:/tqCMnVCrX7F7iL2ALCsGdYmhx0jfgFG/50gP8jt6bI=
+github.com/terra-money/cosmos-sdk v0.44.5-terra.2 h1:v56ZIECZAWerXHE++7JY8GM+oR+W5nt37tKWgEfvl8o=
+github.com/terra-money/cosmos-sdk v0.44.5-terra.2/go.mod h1:/tqCMnVCrX7F7iL2ALCsGdYmhx0jfgFG/50gP8jt6bI=
 github.com/terra-money/ledger-terra-go v0.11.2 h1:BVXZl+OhJOri6vFNjjVaTabRLApw9MuG7mxWL4V718c=
 github.com/terra-money/ledger-terra-go v0.11.2/go.mod h1:ClJ2XMj1ptcnONzKH+GhVPi7Y8pXIT+UzJ0TNt0tfZE=
 github.com/terra-money/tendermint v0.34.14-terra.2 h1:UYDDCI001ZNhs+aX09HjKVldUcz084q3RwLHUOSSZQU=


### PR DESCRIPTION
## Summary of changes

Revert Terra Classic-Core to use cosmos-sdk v0.44.5-terra.2, which is the version of the Cosmos SDK prior to that contained in the TFL security patch installed on 13th May 2022 that disabled delegation and validator node registration, to allow delegation and validator node registation to function again, and so that all LUNC holders may choose to delegate and vote on governance proposals. 

The TFL security patch included in release v0.5.19 is a change to the protocol, which according to the Terra Classic documentation and governance procedures (https://classic-docs.terra.money/docs/learn/protocol.html#governance) requires a proposal and community vote, but no proposal was published and a vote did not happen, and so the patch was installed in contravention to these accepted governance procedures.

We therefore request that those changes be reverted as per this pull request, and that a new release reflecting the changes in this pull request be generated and installed by the validator nodes with coordination from TFL. This request is in keeping with the comments from the TFL developer who created the security patch, @alexanderbez, that “Once… what is being termed as Terra Classic launches, this will be reverted obviously”.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
